### PR TITLE
fix: error-page-header

### DIFF
--- a/src/views/ErrorPage/index.jsx
+++ b/src/views/ErrorPage/index.jsx
@@ -8,7 +8,9 @@ export default function ErrorPage() {
     
     return (
         <div className="error-page-container">
-            <SimpleHeader />
+            <div className="my-[30px]">
+                <SimpleHeader />
+            </div>
             <div className="empty-icon-container">
                 <img className="icon" src={KuboEmptyIcon} alt="Empty icon" />
                 <div className="error-status">


### PR DESCRIPTION
# 🚀 Pull Request

## 📄 Descrição

> O header da página de erro estava completamente colado no topo da página, portanto necessitando conserto.

---

## 🔍 Checklist

- [x] Código funcionando localmente
- [x] Sem conflitos com a `main`/`dev`
- [ ] Testes adicionados ou atualizados
- [ ] Linter / Prettier aplicado
- [ ] Revisado por pelo menos 1 pessoa

---